### PR TITLE
rename metric -> performance_metric

### DIFF
--- a/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.test.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.test.ts
@@ -21,23 +21,23 @@ describe('AnalyticsService', () => {
   test('should register some context providers on creation', async () => {
     expect(analyticsClientMock.registerContextProvider).toHaveBeenCalledTimes(3);
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[0][0].context$)
-    ).resolves.toMatchInlineSnapshot(`
-                  Object {
-                    "branch": "branch",
-                    "buildNum": 100,
-                    "buildSha": "buildSha",
-                    "isDev": true,
-                    "isDistributable": false,
-                    "version": "version",
-                  }
-              `);
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[0][0].context$)
+    ).toMatchInlineSnapshot(`
+            Object {
+              "branch": "branch",
+              "buildNum": 100,
+              "buildSha": "buildSha",
+              "isDev": true,
+              "isDistributable": false,
+              "version": "version",
+            }
+          `);
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[1][0].context$)
-    ).resolves.toEqual({ session_id: expect.any(String) });
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[1][0].context$)
+    ).toEqual({ session_id: expect.any(String) });
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[2][0].context$)
-    ).resolves.toEqual({
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[2][0].context$)
+    ).toEqual({
       preferred_language: 'en-US',
       preferred_languages: ['en-US', 'en'],
       user_agent: expect.any(String),
@@ -210,8 +210,8 @@ describe('AnalyticsService', () => {
     const injectedMetadata = injectedMetadataServiceMock.createSetupContract();
     analyticsService.setup({ injectedMetadata });
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[3][0].context$)
-    ).resolves.toMatchInlineSnapshot(`undefined`);
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[3][0].context$)
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   test('setup should register the elasticsearch info context provider (with info)', async () => {
@@ -223,8 +223,8 @@ describe('AnalyticsService', () => {
     });
     analyticsService.setup({ injectedMetadata });
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[3][0].context$)
-    ).resolves.toMatchInlineSnapshot(`
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[3][0].context$)
+    ).toMatchInlineSnapshot(`
                   Object {
                     "cluster_name": "cluster_name",
                     "cluster_uuid": "cluster_uuid",

--- a/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.ts
@@ -9,7 +9,7 @@
 import { of } from 'rxjs';
 import type { AnalyticsClient } from '@kbn/analytics-client';
 import { createAnalytics } from '@kbn/analytics-client';
-import { registerMetricEventType } from '@kbn/ebt-tools';
+import { registerPerformanceMetricEventType } from '@kbn/ebt-tools';
 import type { CoreContext } from '@kbn/core-base-browser-internal';
 import type { InternalInjectedMetadataSetup } from '@kbn/core-injected-metadata-browser-internal';
 import type { AnalyticsServiceSetup, AnalyticsServiceStart } from '@kbn/core-analytics-browser';
@@ -35,8 +35,8 @@ export class AnalyticsService {
     });
 
     this.registerBuildInfoAnalyticsContext(core);
-    // Register special `metrics` type
-    registerMetricEventType(this.analyticsClient);
+    // Register special `performance_metrics` type
+    registerPerformanceMetricEventType(this.analyticsClient);
 
     // We may eventually move the following to the client's package since they are not Kibana-specific
     // and can benefit other consumers of the client.

--- a/packages/core/analytics/core-analytics-server-internal/src/analytics_service.test.ts
+++ b/packages/core/analytics/core-analytics-server-internal/src/analytics_service.test.ts
@@ -21,8 +21,8 @@ describe('AnalyticsService', () => {
   test('should register the context provider `build info` on creation', async () => {
     expect(analyticsClientMock.registerContextProvider).toHaveBeenCalledTimes(1);
     await expect(
-      firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[0][0].context$)
-    ).resolves.toMatchInlineSnapshot(`
+      await firstValueFrom(analyticsClientMock.registerContextProvider.mock.calls[0][0].context$)
+    ).toMatchInlineSnapshot(`
             Object {
               "branch": "main",
               "buildNum": 9007199254740991,

--- a/packages/core/analytics/core-analytics-server-internal/src/analytics_service.ts
+++ b/packages/core/analytics/core-analytics-server-internal/src/analytics_service.ts
@@ -9,7 +9,7 @@
 import { of } from 'rxjs';
 import type { AnalyticsClient } from '@kbn/analytics-client';
 import { createAnalytics } from '@kbn/analytics-client';
-import { registerMetricEventType } from '@kbn/ebt-tools';
+import { registerPerformanceMetricEventType } from '@kbn/ebt-tools';
 import type { CoreContext } from '@kbn/core-base-server-internal';
 import type {
   AnalyticsServiceSetup,
@@ -31,7 +31,7 @@ export class AnalyticsService {
 
     this.registerBuildInfoAnalyticsContext(core);
     // Register special `metrics` type
-    registerMetricEventType(this.analyticsClient);
+    registerPerformanceMetricEventType(this.analyticsClient);
   }
 
   public preboot(): AnalyticsServicePreboot {

--- a/packages/kbn-ebt-tools/src/metric_events/helpers.ts
+++ b/packages/kbn-ebt-tools/src/metric_events/helpers.ts
@@ -9,16 +9,18 @@
 import type { AnalyticsClient } from '@kbn/analytics-client';
 import { type MetricEvent, METRIC_EVENT_SCHEMA } from './schema';
 
-const METRIC_EVENT_TYPE = 'metric';
+const PERFORMANCE_METRIC_EVENT_TYPE = 'performance_metric';
 
 /**
  * Register the `metrics` event type
  * @param analytics The {@link AnalyticsClient} during the setup phase (it has the method `registerEventType`)
  * @private To be called only by core's Analytics Service
  */
-export function registerMetricEventType(analytics: Pick<AnalyticsClient, 'registerEventType'>) {
+export function registerPerformanceMetricEventType(
+  analytics: Pick<AnalyticsClient, 'registerEventType'>
+) {
   analytics.registerEventType<MetricEvent>({
-    eventType: METRIC_EVENT_TYPE,
+    eventType: PERFORMANCE_METRIC_EVENT_TYPE,
     schema: METRIC_EVENT_SCHEMA,
   });
 }
@@ -28,9 +30,9 @@ export function registerMetricEventType(analytics: Pick<AnalyticsClient, 'regist
  * @param analytics The {@link AnalyticsClient} to report the events.
  * @param eventData The data to send, conforming the structure of a {@link MetricEvent}.
  */
-export function reportMetricEvent(
+export function reportPerformanceMetricEvent(
   analytics: Pick<AnalyticsClient, 'reportEvent'>,
   eventData: MetricEvent
 ) {
-  analytics.reportEvent(METRIC_EVENT_TYPE, eventData);
+  analytics.reportEvent(PERFORMANCE_METRIC_EVENT_TYPE, eventData);
 }

--- a/packages/kbn-ebt-tools/src/metric_events/index.ts
+++ b/packages/kbn-ebt-tools/src/metric_events/index.ts
@@ -6,4 +6,7 @@
  * Side Public License, v 1.
  */
 export type { MetricEvent } from './schema';
-export { registerMetricEventType, reportMetricEvent } from './helpers';
+export {
+  registerPerformanceMetricEventType as registerPerformanceMetricEventType,
+  reportPerformanceMetricEvent,
+} from './helpers';

--- a/packages/kbn-ebt-tools/src/metric_events/schema.ts
+++ b/packages/kbn-ebt-tools/src/metric_events/schema.ts
@@ -25,7 +25,7 @@ export interface MetricEvent {
    * @group Standardized fields
    * The time (in milliseconds) it took to run the entire action.
    */
-  duration?: number;
+  duration: number;
   /**
    * @group Standardized fields
    * A status relevant to the action (i.e.: `failed`, `succeeded`).
@@ -110,7 +110,7 @@ export const METRIC_EVENT_SCHEMA: RootSchema<MetricEvent> = {
   },
   duration: {
     type: 'integer',
-    _meta: { description: 'The main event duration in ms', optional: true },
+    _meta: { description: 'The main event duration in ms' },
   },
   status: {
     type: 'keyword',

--- a/src/core/public/core_system.test.ts
+++ b/src/core/public/core_system.test.ts
@@ -287,7 +287,7 @@ describe('#start()', () => {
   it('reports the metric event kibana-loaded and clears marks', async () => {
     await startCore();
     expect(analyticsServiceStartMock.reportEvent).toHaveBeenCalledTimes(2);
-    expect(analyticsServiceStartMock.reportEvent).toHaveBeenNthCalledWith(2, 'metric', {
+    expect(analyticsServiceStartMock.reportEvent).toHaveBeenNthCalledWith(2, 'performance_metric', {
       eventName: KIBANA_LOADED_EVENT,
       meta: {
         kibana_version: '1.2.3',
@@ -320,7 +320,7 @@ describe('#start()', () => {
     await startCore();
 
     expect(analyticsServiceStartMock.reportEvent).toHaveBeenCalledTimes(2);
-    expect(analyticsServiceStartMock.reportEvent).toHaveBeenNthCalledWith(2, 'metric', {
+    expect(analyticsServiceStartMock.reportEvent).toHaveBeenNthCalledWith(2, 'performance_metric', {
       eventName: KIBANA_LOADED_EVENT,
       meta: {
         kibana_version: '1.2.3',

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -26,7 +26,7 @@ import { HttpService } from '@kbn/core-http-browser-internal';
 import { UiSettingsService } from '@kbn/core-ui-settings-browser-internal';
 import { DeprecationsService } from '@kbn/core-deprecations-browser-internal';
 import { IntegrationsService } from '@kbn/core-integrations-browser-internal';
-import { reportMetricEvent } from '@kbn/ebt-tools';
+import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import { fetchOptionalMemoryInfo } from './fetch_optional_memory_info';
 import { CoreSetup, CoreStart } from '.';
 import { ChromeService } from './chrome';
@@ -164,7 +164,7 @@ export class CoreSystem {
     });
 
     const timing = this.getLoadMarksInfo();
-    reportMetricEvent(analytics, {
+    reportPerformanceMetricEvent(analytics, {
       eventName: KIBANA_LOADED_EVENT,
       meta: {
         kibana_version: this.coreContext.env.packageInfo.version,

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -568,7 +568,7 @@ export class Server {
 
     const ups = this.uptimePerStep;
 
-    const toMs = (sec: number) => Math.round(sec * 100);
+    const toMs = (sec: number) => Math.round(sec * 1000);
     // Report the metric-shaped KIBANA_STARTED_EVENT.
     reportMetricEvent(analyticsStart, {
       eventName: KIBANA_STARTED_EVENT,

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -24,7 +24,7 @@ import {
 import { NodeService, nodeConfig } from '@kbn/core-node-server-internal';
 import { AnalyticsService } from '@kbn/core-analytics-server-internal';
 import type { AnalyticsServiceSetup, AnalyticsServiceStart } from '@kbn/core-analytics-server';
-import { reportMetricEvent } from '@kbn/ebt-tools';
+import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import { EnvironmentService, pidConfig } from '@kbn/core-environment-server-internal';
 import {
   ExecutionContextService,
@@ -570,7 +570,7 @@ export class Server {
 
     const toMs = (sec: number) => Math.round(sec * 1000);
     // Report the metric-shaped KIBANA_STARTED_EVENT.
-    reportMetricEvent(analyticsStart, {
+    reportPerformanceMetricEvent(analyticsStart, {
       eventName: KIBANA_STARTED_EVENT,
       duration: toMs(ups.start!.end - ups.constructor!.start),
       key1: 'time_to_constructor',

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -12,7 +12,7 @@ import { I18nProvider } from '@kbn/i18n-react';
 import uuid from 'uuid';
 import { CoreStart, IUiSettingsClient, KibanaExecutionContext } from '@kbn/core/public';
 import { Start as InspectorStartContract } from '@kbn/inspector-plugin/public';
-import { reportMetricEvent } from '@kbn/ebt-tools';
+import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 
 import { ControlGroupContainer } from '@kbn/controls-plugin/public';
 import { Filter, TimeRange } from '@kbn/es-query';
@@ -166,7 +166,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
 
   private onDataLoaded(data: DashboardLoadedInfo) {
     if (this.services.analytics) {
-      reportMetricEvent(this.services.analytics, {
+      reportPerformanceMetricEvent(this.services.analytics, {
         eventName: DASHBOARD_LOADED_EVENT,
         duration: data.timeToDone,
         status: data.status,

--- a/test/analytics/tests/instrumented_events/from_the_browser/loaded_dashboard.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/loaded_dashboard.ts
@@ -31,7 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     const getEvents = async (count: number, options?: GetEventsOptions) =>
       ebtUIHelper.getEvents(count, {
-        eventTypes: ['metric'],
+        eventTypes: ['performance_metric'],
         fromTimestamp,
         withTimeoutMs: 1000,
         filters: { 'properties.eventName': { eq: DASHBOARD_LOADED_EVENT } },
@@ -42,7 +42,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const events = await getEvents(Number.MAX_SAFE_INTEGER, options);
       expect(events.length).to.be(1);
       const event = events[0];
-      expect(event.event_type).to.eql('metric');
+      expect(event.event_type).to.eql('performance_metric');
       expect(event.properties.eventName).to.eql(DASHBOARD_LOADED_EVENT);
       expect(event.context.applicationId).to.be('dashboards');
       expect(event.context.page).to.be('app');

--- a/test/analytics/tests/instrumented_events/from_the_browser/loaded_kibana.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/loaded_kibana.ts
@@ -31,12 +31,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should emit the new kibana-loaded events', async () => {
       const [event] = await ebtUIHelper.getEvents(1, {
-        eventTypes: ['metric'],
+        eventTypes: ['performance_metric'],
         filters: { 'properties.eventName': { eq: 'kibana_loaded' } },
       });
 
       // New event
-      expect(event.event_type).to.eql('metric');
+      expect(event.event_type).to.eql('performance_metric');
       expect(event.properties.eventName).to.eql('kibana_loaded');
 
       // meta

--- a/test/analytics/tests/instrumented_events/from_the_server/kibana_started.ts
+++ b/test/analytics/tests/instrumented_events/from_the_server/kibana_started.ts
@@ -32,10 +32,10 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('should emit the "kibana_started" metric event', async () => {
       const [event] = await ebtServerHelper.getEvents(1, {
-        eventTypes: ['metric'],
+        eventTypes: ['performance_metric'],
         filters: { 'properties.eventName': { eq: 'kibana_started' } },
       });
-      expect(event.event_type).to.eql('metric');
+      expect(event.event_type).to.eql('performance_metric');
       expect(event.properties.eventName).to.eql('kibana_started');
       expect(event.properties.duration).to.be.a('number');
       expect(event.properties.key1).to.eql('time_to_constructor');


### PR DESCRIPTION
* makes duration field required

* renames metric events to performance_metric_events

* updates usages of reporter functions

* removing .resolves to fix whitespace diff between snapshot updates

* updates snapshots
